### PR TITLE
Simplify use of properties view

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ Library contains:
 
 - [ViewServer](https://github.com/romainguy/ViewServer): helps to debug layouts with more devices.
 
+## Some Comments
+
+- If you want to differentiate release/staging/debug builds on the drawer you need to add:
+
+```
+buildTypes {
+    debug {
+      versionNameSuffix "-staging"  // THIS LINE
+      
+      //...
+    }
+    //...
+}
+```
+
+Looks like we cant get
+
 ## Add to gradle project
 
 ```groovy

--- a/docs/debug-drawer.md
+++ b/docs/debug-drawer.md
@@ -17,20 +17,20 @@ Java:
     String[] hosts = new String[] { "Value 1", "Value 2" };
 
     // Create debug drawer with selected features
-    mDebugDrawer = new DebugDrawer(BaseApplication.sInstance, this)
+    mDebugDrawer = new DebugDrawer(applicationContext, activityContext)
         .withScalpelSwitch((ScalpelFrameLayout) findViewById(R.id.scalpelLayout))
         .withLeakCanarySwitch(true)
         .withPicassoLogsSwitch(true)
         .withStethoSwitch(true)
         // .withShakeToReportBugSwitch(false, repositoryBuilder)
-        .withDivider()
+        .withDivider() // a line like this ------------------ in the drawer 
         .withLynksButton()
         .withPhoenixRestartButton(this)
         .withDivider()
         .withInputItem(2, "Host", this)
         .withSpinnerItem(1, "Spinner with item selected by index", hosts, 0, this)
         .withDivider()
-        .withInfoProperties(getProperties());
+        .withInfoProperties(dictionaryWithProperties);
 
     // Enable view debuger on some devices
     ViewServer.get(this).addWindow(this);

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -55,12 +55,7 @@ dependencies {
   testCompile 'junit:junit:4.12'
   testCompile "org.mockito:mockito-core:2.6.3"
   testCompile "com.nhaarman:mockito-kotlin:1.1.0"
-
-  testCompile "org.jetbrains.spek:spek-api:$versions.spek"
-  testCompile "org.jetbrains.spek:spek-junit-platform-engine:$versions.spek"
   testCompile "org.jetbrains.kotlin:kotlin-test-junit:$versions.kotlin"
-
-  testCompile 'org.junit.platform:junit-platform-runner:1.0.0-M3'
 }
 
 // SHOULD BE AT THE BOTTOM OF THE FILE, DONT MOVE

--- a/lib/src/main/java/debug_artist/menu/drawer/DebugDrawer.kt
+++ b/lib/src/main/java/debug_artist/menu/drawer/DebugDrawer.kt
@@ -1,9 +1,9 @@
 package debug_artist.menu.drawer
 
+import android.app.Activity
 import android.app.Application
 import android.support.annotation.StringRes
 import android.support.v7.app.AlertDialog
-import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.RecyclerView
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -31,8 +31,8 @@ import debug_artist.menu.drawer.item.spinner.SpinnerDrawerItem
 import debug_artist.menu.drawer.item.spinner.SpinnerItemListener
 import debug_artist.menu.report_bug.BugRepository
 import debug_artist.menu.utils.device.AndroidDevice
+import debug_artist.menu.utils.device.AndroidDevice.Companion.getProjectProperties
 import debug_artist.menu.utils.shake_detector.AndroidShakeDetector
-import java.lang.ref.WeakReference
 
 /**
  * Debug drawer showing some debugging tools and info.
@@ -40,11 +40,10 @@ import java.lang.ref.WeakReference
  * To add dynamic actions check "debugDrawer.with*" methods.
  */
 class DebugDrawer @JvmOverloads constructor(application: Application,
-                                            activity: AppCompatActivity,
+                                            val activity: Activity,
                                             showDrawerOnFirstLaunch: Boolean = false)
   : OnCheckedChangeListener, Drawer.OnDrawerItemClickListener, SpinnerItemListener, DebugDrawerView {
 
-  private val activityWeakReference = WeakReference(activity)
   private val presenter = DebugDrawerPresenter()
   private val debugActor = DebugActor(application, activity)
   private val menuDrawer = DrawerBuilder(activity)
@@ -114,7 +113,7 @@ class DebugDrawer @JvmOverloads constructor(application: Application,
                       listener: SpinnerItemListener) =
       withMenuItem(SpinnerMenuItem(id, name, options, selectedItem, listener))
 
-  fun withInfoProperties(properties: Map<String, String>) = withMenuItem(LabelMenuItem(properties))
+  fun withInfoProperties() = withMenuItem(LabelMenuItem(getProjectProperties(activity)))
 
   //</editor-fold>
 
@@ -170,7 +169,7 @@ class DebugDrawer @JvmOverloads constructor(application: Application,
   }
 
   override fun addInputItem(item: InputMenuItem) {
-    val text = activityWeakReference.get()?.getString(R.string.enter_value_for, item.name) ?: ""
+    val text = activity.getString(R.string.enter_value_for, item.name) ?: ""
 
     menuDrawer.addItem(PrimaryDrawerItem()
         .withName(text)
@@ -187,24 +186,20 @@ class DebugDrawer @JvmOverloads constructor(application: Application,
   }
 
   override fun showErrorDialog(message: String) {
-    activityWeakReference.get()?.let {
-      Toast.makeText(it, message, LENGTH_LONG).show()
-    }
+    Toast.makeText(activity, message, LENGTH_LONG).show()
   }
 
   override fun showSuccessToast() {
-    activityWeakReference.get()?.let {
-      Toast.makeText(it, "Success", LENGTH_SHORT).show()
-    }
+    Toast.makeText(activity, "Success", LENGTH_SHORT).show()
   }
 
   //</editor-fold>
 
-  private fun showInputDialog(drawerItem: PrimaryDrawerItem) = activityWeakReference.get()?.let {
-    val factory = LayoutInflater.from(it)
+  private fun showInputDialog(drawerItem: PrimaryDrawerItem) {
+    val factory = LayoutInflater.from(activity)
     val entryView = factory.inflate(R.layout.input_view, null) as EditText
 
-    AlertDialog.Builder(it)
+    AlertDialog.Builder(activity)
         .setTitle(drawerItem.name.toString())
         .setView(entryView)
         .setPositiveButton(android.R.string.yes) { dialog, which ->

--- a/lib/src/main/java/debug_artist/menu/drawer/DebugDrawerPresenter.kt
+++ b/lib/src/main/java/debug_artist/menu/drawer/DebugDrawerPresenter.kt
@@ -5,7 +5,7 @@ import debug_artist.menu.drawer.item.*
 import debug_artist.menu.drawer.item.input.InputItemListener
 import debug_artist.menu.drawer.item.phoenix.RestartListener
 import debug_artist.menu.report_bug.BugRepository
-import debug_artist.menu.utils.device.Device
+import debug_artist.menu.utils.device.AndroidDevice
 import debug_artist.menu.utils.shake_detector.OnShakeListener
 import debug_artist.menu.utils.shake_detector.ShakeDetector
 
@@ -19,10 +19,10 @@ class DebugDrawerPresenter : OnShakeListener {
   @VisibleForTesting internal var inputItemListener: InputItemListener? = null
 
   private var traveler: Traveler? = null
-  private var device: Device? = null
+  private var device: AndroidDevice? = null
 
   fun attach(view: DebugDrawerView, traveler: Traveler,
-             actor: Actor, shakeDetector: ShakeDetector, device: Device) {
+             actor: Actor, shakeDetector: ShakeDetector, device: AndroidDevice) {
     this.view = view
     this.traveler = traveler
     this.actor = actor

--- a/lib/src/main/java/debug_artist/menu/drawer/DebugDrawerTraveler.kt
+++ b/lib/src/main/java/debug_artist/menu/drawer/DebugDrawerTraveler.kt
@@ -1,6 +1,6 @@
 package debug_artist.menu.drawer
 
-import android.support.v4.app.FragmentActivity
+import android.app.Activity
 import debug_artist.menu.report_bug.ReportBugActivity
 import debug_artist.menu.report_bug.BugRepository
 
@@ -8,7 +8,7 @@ interface Traveler {
   fun startBugReportView(builder: BugRepository.Builder, screenshotFilePath: String, logsFilePath: String)
 }
 
-class DebugDrawerTraveler(val activity: FragmentActivity) : Traveler {
+class DebugDrawerTraveler(val activity: Activity) : Traveler {
 
   override fun startBugReportView(builder: BugRepository.Builder, screenshotFilePath: String, logsFilePath: String) =
       activity.startActivity(ReportBugActivity.getInstance(activity, builder, screenshotFilePath, logsFilePath))

--- a/lib/src/main/java/debug_artist/menu/report_bug/ExtrasHandler.kt
+++ b/lib/src/main/java/debug_artist/menu/report_bug/ExtrasHandler.kt
@@ -1,9 +1,8 @@
 package debug_artist.menu.report_bug
 
+import android.app.Activity
 import android.content.Intent
-import android.support.v4.app.FragmentActivity
 import debug_artist.menu.report_bug.ReportBugActivity
-import debug_artist.menu.report_bug.BugRepository
 
 interface ExtrasHandler {
   val extraRepositoryBuilder: BugRepository.Builder
@@ -18,7 +17,7 @@ class ExtrasHandlerImpl(intent: Intent) : ExtrasHandler {
     internal val extraScreenshot = "report.screenshot"
     internal val extraLogs = "report.logs"
 
-    fun getInstance(activity: FragmentActivity, repositoryBuilder: BugRepository.Builder,
+    fun getInstance(activity: Activity, repositoryBuilder: BugRepository.Builder,
                     screenshotFilePath: String, logsFilePath: String) =
         Intent(activity, ReportBugActivity::class.java).apply {
           putExtra(ExtrasHandlerImpl.Companion.extraRepository, repositoryBuilder)

--- a/lib/src/main/java/debug_artist/menu/report_bug/ReportBugActivity.kt
+++ b/lib/src/main/java/debug_artist/menu/report_bug/ReportBugActivity.kt
@@ -1,9 +1,9 @@
 package debug_artist.menu.report_bug
 
+import android.app.Activity
 import android.app.ProgressDialog
 import android.net.Uri
 import android.os.Bundle
-import android.support.v4.app.FragmentActivity
 import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
@@ -19,7 +19,7 @@ import java.lang.ref.WeakReference
 class ReportBugActivity : AppCompatActivity(), ReportBugView {
 
   companion object {
-    fun getInstance(activity: FragmentActivity,
+    fun getInstance(activity: Activity,
                     repositoryBuilder: BugRepository.Builder,
                     screenshotFilePath: String, logsFilePath: String) =
         ExtrasHandlerImpl.getInstance(activity, repositoryBuilder, screenshotFilePath, logsFilePath)

--- a/lib/src/main/java/debug_artist/menu/report_bug/ReportBugTraveler.kt
+++ b/lib/src/main/java/debug_artist/menu/report_bug/ReportBugTraveler.kt
@@ -1,12 +1,13 @@
 package debug_artist.menu.report_bug
 
-import android.support.v4.app.FragmentActivity
+import android.app.Activity
+
 
 interface ReportBugTraveler {
   fun close()
 }
 
-class ReportBugTravelerImpl(val activity: FragmentActivity) : ReportBugTraveler {
+class ReportBugTravelerImpl(val activity: Activity) : ReportBugTraveler {
 
   override fun close() = activity.finish()
 

--- a/lib/src/main/java/debug_artist/menu/utils/device/AndroidDevice.kt
+++ b/lib/src/main/java/debug_artist/menu/utils/device/AndroidDevice.kt
@@ -1,7 +1,8 @@
 package debug_artist.menu.utils.device
 
+import android.app.Activity
+import android.os.Build
 import android.os.Process
-import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import com.jraska.falcon.Falcon
 import java.io.*
@@ -9,12 +10,35 @@ import java.io.*
 /**
  * Know how to pick things from an Android Device.
  */
-class AndroidDevice(val activity: AppCompatActivity) : Device {
+class AndroidDevice(val activity: Activity) {
 
   val TAG = "AndroidDevice"
 
+  companion object {
+
+    /**
+     * Return a map with keys and values referencing environment variables like
+     * app version, android version, model, etc...
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun getProjectProperties(activity: Activity, extraProperties: HashMap<String, String>? = null)
+        : MutableMap<String, String> {
+      return activity.packageManager.getPackageInfo(activity.packageName, 0).let {
+        mutableMapOf<String, String>(
+            "AppVersion" to it.versionName,
+            "Build" to it.versionCode.toString(),
+            "AndroidVersion" to Build.VERSION.RELEASE,
+            "Manufacturer" to Build.MANUFACTURER,
+            "Model" to Build.MODEL).apply {
+          extraProperties?.let { putAll(extraProperties) }
+        }
+      }
+    }
+  }
+
   @Throws(Falcon.UnableToTakeScreenshotException::class)
-  override fun takeScreenshot(fileName: String): String {
+  fun takeScreenshot(fileName: String): String {
     val outFile = File(activity.cacheDir, fileName)
     Falcon.takeScreenshot(activity, outFile)
     return outFile.path
@@ -26,7 +50,7 @@ class AndroidDevice(val activity: AppCompatActivity) : Device {
    *
    * Source: http://stackoverflow.com/a/22174245/273119
    */
-  override fun readLogFile(): String {
+  fun readLogFile(): String {
     val fullName = "appLog.log"
     val file = File(activity.cacheDir, fullName)
     val pid = Process.myPid().toString()

--- a/lib/src/main/java/debug_artist/menu/utils/device/Device.kt
+++ b/lib/src/main/java/debug_artist/menu/utils/device/Device.kt
@@ -1,8 +1,0 @@
-package debug_artist.menu.utils.device
-
-interface Device {
-  @Throws(Exception::class)
-  fun takeScreenshot(fileName: String): String
-
-  fun readLogFile(): String
-}

--- a/lib/src/test/java/debug_artist/menu/DebugDrawerPresenterTests.kt
+++ b/lib/src/test/java/debug_artist/menu/DebugDrawerPresenterTests.kt
@@ -1,16 +1,18 @@
-package debug_artist.menu.drawer
+package debug_artist.menu
 
 import com.nhaarman.mockito_kotlin.*
-import debug_artist.menu.MockFactory
+import debug_artist.menu.drawer.Actor
+import debug_artist.menu.drawer.DebugDrawerPresenter
+import debug_artist.menu.drawer.DebugDrawerView
+import debug_artist.menu.drawer.Traveler
 import debug_artist.menu.drawer.item.LeakCanarySwitchMenuItem
 import debug_artist.menu.drawer.item.LynksButtonMenuItem
 import debug_artist.menu.drawer.item.PicassoLogsSwitchMenuItem
 import debug_artist.menu.drawer.item.StethoSwitchMenuItem
 import debug_artist.menu.drawer.item.input.InputItemListener
 import debug_artist.menu.report_bug.BugRepository
-import debug_artist.menu.utils.device.Device
+import debug_artist.menu.utils.device.AndroidDevice
 import debug_artist.menu.utils.shake_detector.ShakeDetector
-import debug_artist.mockSchedulers
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
@@ -30,7 +32,7 @@ class DebugDrawerPresenterTests : Spek({
     val actor = mock<Actor>()
     val shakeDetector = mock<ShakeDetector>()
     val traveler = mock<Traveler>()
-    val device = mock<Device>()
+    val device = mock<AndroidDevice>()
     var presenter = DebugDrawerPresenter()
 
     beforeEachTest {
@@ -303,4 +305,6 @@ class DebugDrawerPresenterTests : Spek({
     }
 
   }
-})
+}
+
+                                      )

--- a/lib/src/test/java/debug_artist/menu/DebugDrawerPresenterTests.kt
+++ b/lib/src/test/java/debug_artist/menu/DebugDrawerPresenterTests.kt
@@ -1,5 +1,6 @@
 package debug_artist.menu
 
+import com.jraska.falcon.Falcon
 import com.nhaarman.mockito_kotlin.*
 import debug_artist.menu.drawer.Actor
 import debug_artist.menu.drawer.DebugDrawerPresenter
@@ -13,298 +14,250 @@ import debug_artist.menu.drawer.item.input.InputItemListener
 import debug_artist.menu.report_bug.BugRepository
 import debug_artist.menu.utils.device.AndroidDevice
 import debug_artist.menu.utils.shake_detector.ShakeDetector
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
+import org.junit.Before
+import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import kotlin.test.assertNull
 
-@RunWith(JUnitPlatform::class)
-class DebugDrawerPresenterTests : Spek({
-  mockSchedulers()
-
-  describe("a new DebugDrawer presenter") {
-    val view = mock<DebugDrawerView>()
-    val actor = mock<Actor>()
-    val shakeDetector = mock<ShakeDetector>()
-    val traveler = mock<Traveler>()
-    val device = mock<AndroidDevice>()
-    var presenter = DebugDrawerPresenter()
-
-    beforeEachTest {
-      Mockito.reset(view, traveler, actor, shakeDetector, device)
-
-      presenter = DebugDrawerPresenter().apply {
-        attach(view, traveler, actor, shakeDetector, device)
-      }
-    }
-
-    on("pause") {
-      presenter.deAttach()
-
-      it("should release resources") {
-        assertNull(presenter.view)
-        assertNull(presenter.actor)
-        assertNull(presenter.inputItemListener)
-        assertNull(presenter.restartListener)
-        verify(shakeDetector).pause()
-      }
-    }
-
-    on("add switch stetho checked") {
-      presenter.onItemAdded(StethoSwitchMenuItem(checked = true))
-
-      it("should enable") {
-        verify(actor).enableStetho()
-        verify(view).addStethoSwitch(true)
-      }
-    }
-
-    on("add switch stetho unchecked") {
-      presenter.onItemAdded(StethoSwitchMenuItem())
-
-      it("should not enable") {
-        verifyZeroInteractions(actor)
-        verify(view).addStethoSwitch(false)
-      }
-    }
-
-    on("add switch Leak Canary checked") {
-      presenter.onItemAdded(LeakCanarySwitchMenuItem(checked = true))
-
-      it("should enable it") {
-        verify(actor).enableLeakCanary()
-        verify(view).addLeakCanarySwitch(true)
-      }
-    }
-
-    on("add switch Leak Canary unchecked") {
-      presenter.onItemAdded(LeakCanarySwitchMenuItem())
-
-      it("should not enable") {
-        verifyZeroInteractions(actor)
-        verify(view).addLeakCanarySwitch(false)
-      }
-    }
-
-    on("add switch Picasso Logs checked") {
-      presenter.onItemAdded(PicassoLogsSwitchMenuItem(checked = true))
-
-      it("should enable it") {
-        verify(actor).enablePicassoLogs()
-        verify(view).addPicassoLogsSwitch(true)
-      }
-    }
-
-    on("add switch Picasso Logs unchecked") {
-      presenter.onItemAdded(PicassoLogsSwitchMenuItem())
-
-      it("should enable it") {
-        verifyZeroInteractions(actor)
-        verify(view).addPicassoLogsSwitch(false)
-      }
-    }
-
-    on("add switch Scalpel Layout checked") {
-      presenter.onItemAdded(MockFactory.scalpelSwitchMenuItem(checked = true))
-
-      it("should enable it") {
-        verify(actor).enableScalpelLayout()
-        verify(view).addScalpelSwitch(true)
-      }
-    }
-
-    on("add switch Scalpel Layout unchecked") {
-      presenter.onItemAdded(MockFactory.scalpelSwitchMenuItem())
-
-      it("should enable it") {
-        verify(actor, times(0)).enableScalpelLayout()
-        verify(view).addScalpelSwitch(false)
-      }
-    }
-
-    on("add button Lynks") {
-      presenter.onItemAdded(LynksButtonMenuItem())
-
-      it("should add") {
-        verify(view).addLynksButton()
-      }
-    }
-
-    on("add button Phoenix") {
-      presenter.onItemAdded(MockFactory.phoenixButtonMenuItem())
-
-      it("should add") {
-        verify(view).addPhoenixButton()
-      }
-    }
-
-    on("add button Spinner") {
-      val item = MockFactory.spinnerMenuItem()
-      presenter.onItemAdded(item)
-
-      it("should add") {
-        verify(view).addSpinnerItem(item)
-      }
-    }
-
-    on("add button Input") {
-      val item = MockFactory.inputMenuItem()
-      presenter.onItemAdded(item)
-
-      it("should add") {
-        verify(view).addInputItem(item)
-      }
-    }
-
-    on("add button report bug") {
-      val item = MockFactory.reportBugItem(true)
-      presenter.onItemAdded(item)
-
-      it("should add and start shake detector") {
-        verify(view).addBugReportSwitch(true)
-        verify(shakeDetector).start(presenter)
-      }
-    }
-
-    on("lynks item selected") {
-      presenter.onLynksItemSelected()
-
-      it("should enable lynks") {
-        verify(actor).enableLynx()
-      }
-    }
-
-    on("phoenix item selected") {
-      presenter.onPhoenixItemSelected()
-
-      it("should trigger app rebirth") {
-        verify(actor).triggerAppRebirth()
-      }
-    }
-
-    on("picasso item selected") {
-      presenter.onPicassoItemSelected()
-
-      it("should enable picasso logs") {
-        verify(actor).enablePicassoLogs()
-      }
-    }
-
-    on("scalpel item checked") {
-      presenter.onScalpelItemSelected(true)
-
-      it("should enable scalpel") {
-        verify(actor).enableScalpelLayout()
-      }
-    }
-
-    on("scalpel item unchecked") {
-      presenter.onScalpelItemSelected(false)
-
-      it("should disable scalpel") {
-        verify(actor).disableScalpelLayout()
-      }
-    }
-
-    on("stetho item checked") {
-      presenter.onStethoItemSelected()
-
-      it("should enable stetho") {
-        verify(actor).enableStetho()
-      }
-    }
-
-    on("bug-reporter item checked") {
-      presenter.onBugReporterItemSelected(true)
-
-      it("should start listening for shakes") {
-        verify(shakeDetector).start(presenter)
-      }
-    }
-
-    on("bug-reporter item unchecked") {
-      presenter.onBugReporterItemSelected(false)
-
-      it("should pause listening for shakes") {
-        verify(shakeDetector).pause()
-      }
-    }
-
-    on("shake with count 2") {
-      presenter.onShake(2)
-
-      it("should do nothing") {
-        verifyNoMoreInteractions(view, actor, traveler, shakeDetector, device)
-      }
-    }
-
-    on("shake with right count and all files loaded") {
-      val repositoryBuilder = mock<BugRepository.Builder>()
-
-      whenever(device.takeScreenshot(anyString())).thenReturn("any.jpg")
-      whenever(device.readLogFile()).thenReturn("log.log")
-
-      presenter.bugRepositoryBuilder = repositoryBuilder
-      presenter.onShake(1)
-
-      it("should start report bug view") {
-        verify(traveler).startBugReportView(repositoryBuilder, "any.jpg", "log.log")
-      }
-    }
-
-    on("shake with right count and null screenshot file") {
-      whenever(device.takeScreenshot(anyString())).thenReturn(null)
-      whenever(device.readLogFile()).thenReturn("log.log")
-
-      presenter.bugRepositoryBuilder = mock<BugRepository.Builder>()
-      presenter.onShake(1)
-
-      it("should do nothing") {
-        verifyZeroInteractions(view, actor, shakeDetector, traveler)
-      }
-    }
-
-    on("shake with right count and null log file") {
-      whenever(device.takeScreenshot(anyString())).thenReturn("any.jpg")
-      whenever(device.readLogFile()).thenReturn(null)
-
-      presenter.bugRepositoryBuilder = mock<BugRepository.Builder>()
-      presenter.onShake(1)
-
-      it("should do nothing") {
-        verifyZeroInteractions(view, actor, shakeDetector, traveler)
-      }
-    }
-
-    on("shake with right count but screenshot throws exception") {
-      val error = Exception("failed")
-      whenever(device.takeScreenshot(anyString())).thenThrow(error)
-      whenever(device.readLogFile()).thenReturn("log.log")
-
-      presenter.onShake(1)
-
-      it("should show error") {
-        verify(view).showErrorDialog(anyString())
-      }
-    }
-
-    on("text input entered") {
-      val inputListener = mock<InputItemListener>()
-
-      presenter.inputItemListener = inputListener
-      presenter.onTextInputEntered(1, "asd")
-
-      it("call listener with same values") {
-        verify(inputListener).onTextInputEnter(1, "asd")
-      }
-    }
-
+class DebugDrawerPresenterTests {
+  val view: DebugDrawerView = mock()
+  val actor: Actor = mock()
+  val shakeDetector: ShakeDetector = mock()
+  val traveler: Traveler = mock()
+  val device: AndroidDevice = mock()
+
+  lateinit var presenter: DebugDrawerPresenter
+
+  @Before
+  fun setUp() {
+    mockSchedulers()
+
+    Mockito.reset(view, traveler, actor, shakeDetector, device)
+
+    presenter = DebugDrawerPresenter()
+    presenter.attach(view, traveler, actor, shakeDetector, device)
   }
-}
 
-                                      )
+  @Test
+  fun test_onDettach_releaseResources() {
+    presenter.deAttach()
+
+    assertNull(presenter.view)
+    assertNull(presenter.actor)
+    assertNull(presenter.inputItemListener)
+    assertNull(presenter.restartListener)
+    verify(shakeDetector).pause()
+  }
+
+  @Test
+  fun test_onStethoAdded_ifChecked_enable() {
+    presenter.onItemAdded(StethoSwitchMenuItem(checked = true))
+
+    verify(actor).enableStetho()
+    verify(view).addStethoSwitch(true)
+  }
+
+  @Test
+  fun test_onStethoAdded_ifUnchecked_dontEnable() {
+    presenter.onItemAdded(StethoSwitchMenuItem())
+
+    verifyZeroInteractions(actor)
+    verify(view).addStethoSwitch(false)
+  }
+
+  @Test
+  fun test_onLeakAdded_ifChecked_enable() {
+    presenter.onItemAdded(LeakCanarySwitchMenuItem(checked = true))
+
+    verify(actor).enableLeakCanary()
+    verify(view).addLeakCanarySwitch(true)
+  }
+
+  @Test
+  fun test_onLeakAdded_ifNotChecked_dontEnable() {
+    presenter.onItemAdded(LeakCanarySwitchMenuItem())
+
+    verifyZeroInteractions(actor)
+    verify(view).addLeakCanarySwitch(false)
+  }
+
+  @Test
+  fun test_onPicassoAdded_ifChecked_enable() {
+    presenter.onItemAdded(PicassoLogsSwitchMenuItem(checked = true))
+
+    verify(actor).enablePicassoLogs()
+    verify(view).addPicassoLogsSwitch(true)
+  }
+
+  @Test
+  fun test_onPicassoAdded_ifNotChecked_dontEnable() {
+    presenter.onItemAdded(PicassoLogsSwitchMenuItem())
+
+    verifyZeroInteractions(actor)
+    verify(view).addPicassoLogsSwitch(false)
+  }
+
+  @Test
+  fun test_onScalpelAdded_ifChecked_enable() {
+    presenter.onItemAdded(MockFactory.scalpelSwitchMenuItem(checked = true))
+
+    verify(actor).enableScalpelLayout()
+    verify(view).addScalpelSwitch(true)
+  }
+
+  @Test
+  fun test_onScalpelAdded_ifNotChecked_dontEnable() {
+    presenter.onItemAdded(MockFactory.scalpelSwitchMenuItem())
+
+    verify(actor, times(0)).enableScalpelLayout()
+    verify(view).addScalpelSwitch(false)
+  }
+
+  @Test
+  fun test_onLynksAdded_add() {
+    presenter.onItemAdded(LynksButtonMenuItem())
+    verify(view).addLynksButton()
+  }
+
+  @Test
+  fun test_onPhoenixAdded_add() {
+    presenter.onItemAdded(MockFactory.phoenixButtonMenuItem())
+    verify(view).addPhoenixButton()
+  }
+
+  @Test
+  fun test_onSpinnerAdded_add() {
+    val item = MockFactory.spinnerMenuItem()
+    presenter.onItemAdded(item)
+    verify(view).addSpinnerItem(item)
+  }
+
+  @Test
+  fun test_onInputAdded_add() {
+    val item = MockFactory.inputMenuItem()
+    presenter.onItemAdded(item)
+    verify(view).addInputItem(item)
+  }
+
+  @Test
+  fun test_reportBugAdded_enable_andStartShakeDetector() {
+    val item = MockFactory.reportBugItem(true)
+
+    presenter.onItemAdded(item)
+
+    verify(view).addBugReportSwitch(true)
+    verify(shakeDetector).start(presenter)
+  }
+
+  @Test
+  fun test_onLynksSelected_enable() {
+    presenter.onLynksItemSelected()
+    verify(actor).enableLynx()
+  }
+
+  @Test
+  fun test_onPhoenixSelected_trigger() {
+    presenter.onPhoenixItemSelected()
+    verify(actor).triggerAppRebirth()
+  }
+
+  @Test
+  fun test_onPicassoSelected_enable() {
+    presenter.onPicassoItemSelected()
+    verify(actor).enablePicassoLogs()
+  }
+
+  @Test
+  fun test_onScalpelSelected_ifChecked_enable() {
+    presenter.onScalpelItemSelected(true)
+    verify(actor).enableScalpelLayout()
+  }
+
+  @Test
+  fun test_onScalpelSelected_ifNotChecked_disable() {
+    presenter.onScalpelItemSelected(false)
+    verify(actor).disableScalpelLayout()
+  }
+
+  @Test
+  fun test_onStethoSelected_enable() {
+    presenter.onStethoItemSelected()
+    verify(actor).enableStetho()
+  }
+
+  @Test
+  fun test_onReportBugSelected_ifChecked_startShakeListener() {
+    presenter.onBugReporterItemSelected(true)
+    verify(shakeDetector).start(presenter)
+  }
+
+  @Test
+  fun test_bugReporterSelected_ifNotChecked_pauseShakeListener() {
+    presenter.onBugReporterItemSelected(false)
+    verify(shakeDetector).pause()
+  }
+
+  @Test
+  fun test_onShake_with2_doNothing() {
+    presenter.onShake(2)
+    verifyNoMoreInteractions(view, actor, traveler, shakeDetector, device)
+  }
+
+  @Test
+  fun test_onShake_with1_startReportBug() {
+    val repositoryBuilder = mock<BugRepository.Builder>()
+
+    whenever(device.takeScreenshot(anyString())).thenReturn("any.jpg")
+    whenever(device.readLogFile()).thenReturn("log.log")
+
+    presenter.bugRepositoryBuilder = repositoryBuilder
+    presenter.onShake(1)
+
+    verify(traveler).startBugReportView(repositoryBuilder, "any.jpg", "log.log")
+  }
+
+  @Test
+  fun test_onShake_with1_withNullScreenshot_doNothing() {
+    whenever(device.takeScreenshot(anyString())).thenReturn(null)
+    whenever(device.readLogFile()).thenReturn("log.log")
+
+    presenter.bugRepositoryBuilder = mock<BugRepository.Builder>()
+    presenter.onShake(1)
+
+    verifyZeroInteractions(view, actor, shakeDetector, traveler)
+  }
+
+  @Test
+  fun test_onShake_with1_withNullLogFile_doNothing() {
+    whenever(device.takeScreenshot(anyString())).thenReturn("any.jpg")
+    whenever(device.readLogFile()).thenReturn(null)
+
+    presenter.bugRepositoryBuilder = mock<BugRepository.Builder>()
+    presenter.onShake(1)
+
+    verifyZeroInteractions(view, actor, shakeDetector, traveler)
+  }
+
+  @Test
+  fun test_onShake_with1_withExceptionTakingScreenshot_showError() {
+    val error = mock<Falcon.UnableToTakeScreenshotException>()
+    whenever(device.takeScreenshot(anyString())).thenThrow(error)
+    whenever(device.readLogFile()).thenReturn("log.log")
+
+    presenter.onShake(1)
+
+    verify(view).showErrorDialog(anyString())
+  }
+
+  @Test
+  fun test_onInput_callListenerWithSameValues() {
+    val inputListener = mock<InputItemListener>()
+
+    presenter.inputItemListener = inputListener
+    presenter.onTextInputEntered(1, "asd")
+
+    verify(inputListener).onTextInputEnter(1, "asd")
+  }
+
+}

--- a/lib/src/test/java/debug_artist/menu/TestSetup.kt
+++ b/lib/src/test/java/debug_artist/menu/TestSetup.kt
@@ -1,4 +1,4 @@
-package debug_artist
+package debug_artist.menu
 
 import rx.android.plugins.RxAndroidPlugins
 import rx.android.plugins.RxAndroidSchedulersHook

--- a/lib/src/test/java/debug_artist/menu/report_bug/ReportBugPresenterTests.kt
+++ b/lib/src/test/java/debug_artist/menu/report_bug/ReportBugPresenterTests.kt
@@ -2,7 +2,7 @@ package debug_artist.menu.report_bug
 
 import debug_artist.menu.MockFactory.answer
 import debug_artist.menu.report_bug.*
-import debug_artist.mockSchedulers
+import debug_artist.menu.mockSchedulers
 import com.nhaarman.mockito_kotlin.*
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe

--- a/lib/src/test/java/debug_artist/menu/report_bug/ReportBugPresenterTests.kt
+++ b/lib/src/test/java/debug_artist/menu/report_bug/ReportBugPresenterTests.kt
@@ -1,124 +1,94 @@
 package debug_artist.menu.report_bug
 
-import debug_artist.menu.MockFactory.answer
-import debug_artist.menu.report_bug.*
-import debug_artist.menu.mockSchedulers
 import com.nhaarman.mockito_kotlin.*
-import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
-import org.jetbrains.spek.api.dsl.on
-import org.junit.platform.runner.JUnitPlatform
-import org.junit.runner.RunWith
+import debug_artist.menu.MockFactory.answer
+import debug_artist.menu.mockSchedulers
+import org.junit.Before
+import org.junit.Test
 import org.mockito.Mockito
-import rx.Observable.error
+import rx.Observable
 
-@RunWith(JUnitPlatform::class)
-class ReportBugPresenterTests : Spek({
+class ReportBugPresenterTests {
+  val view: ReportBugView = mock()
+  val bugRepositoryBuilder: BugRepository.Builder = mock()
+  val bugRepository: BugRepository = mock()
+  val extrasHandler: ExtrasHandler = mock()
+  val traveler: ReportBugTraveler = mock()
 
-  describe("a new ReportBug presenter") {
-    val view = mock<ReportBugView>()
-    val bugRepositoryBuilder = mock<BugRepository.Builder>()
-    val bugRepository = mock<BugRepository>()
-    val extrasHandler = mock<ExtrasHandler>()
-    var presenter = ReportBugPresenter()
-    val traveler = mock<ReportBugTraveler>()
+  var presenter = ReportBugPresenter()
 
-    beforeEachTest {
-      mockSchedulers()
+  @Before
+  fun setUp() {
+    mockSchedulers()
 
-      whenever(bugRepositoryBuilder.build()).thenReturn(bugRepository)
-      whenever(extrasHandler.extraRepositoryBuilder).thenReturn(bugRepositoryBuilder)
-      whenever(extrasHandler.screenshotFilePath).thenReturn("any.jpg")
+    whenever(bugRepositoryBuilder.build()).thenReturn(bugRepository)
+    whenever(extrasHandler.extraRepositoryBuilder).thenReturn(bugRepositoryBuilder)
+    whenever(extrasHandler.screenshotFilePath).thenReturn("any.jpg")
 
-      presenter = ReportBugPresenter().apply { attach(view, traveler, extrasHandler) }
+    presenter = ReportBugPresenter().apply { attach(view, traveler, extrasHandler) }
 
-      Mockito.reset(view, bugRepositoryBuilder, bugRepository, extrasHandler, traveler)
-    }
-
-    on("attach") {
-      whenever(bugRepositoryBuilder.build()).thenReturn(bugRepository)
-      whenever(extrasHandler.extraRepositoryBuilder).thenReturn(bugRepositoryBuilder)
-      whenever(extrasHandler.screenshotFilePath).thenReturn("any.jpg")
-
-      presenter.attach(view, traveler, extrasHandler)
-
-      it("should build repository") {
-        verify(bugRepositoryBuilder).build()
-      }
-
-      it("should set screenshot image") {
-        verify(view).setScreenshotImage("any.jpg")
-      }
-    }
-
-    on("sendButton with success") {
-      whenever(extrasHandler.screenshotFilePath).thenReturn("any.jpg")
-      whenever(extrasHandler.logsFilePath).thenReturn("log.log")
-      whenever(bugRepository.create("title", "description", "any.jpg", "log.log"))
-          .thenReturn(answer())
-
-      presenter.onSendButtonClick("title", "description")
-
-      it("should create bug") {
-        verify(view).apply {
-          showProgressDialog()
-          dismissProgressDialog()
-          showSuccessToast()
-        }
-      }
-
-      it("should close") {
-        verify(traveler).close()
-      }
-    }
-
-    on("sendButton with empty title") {
-      presenter.onSendButtonClick("", "description")
-
-      it("should show error") {
-        verify(view).apply {
-          showErrorDialog(any())
-        }
-
-        verifyNoMoreInteractions(view)
-      }
-    }
-
-    on("sendButton with empty description") {
-      presenter.onSendButtonClick("title", "")
-
-      it("should show error") {
-        verify(view).apply {
-          showErrorDialog(any())
-        }
-
-        verifyNoMoreInteractions(view)
-      }
-    }
-
-    on("sendButton with error") {
-      val error = Throwable("Something happened")
-
-      whenever(extrasHandler.screenshotFilePath).thenReturn("any.jpg")
-      whenever(extrasHandler.logsFilePath).thenReturn("log.log")
-      whenever(bugRepository.create("title", "description", "any.jpg", "log.log"))
-          .thenReturn(error(error))
-
-      presenter.onSendButtonClick("title", "description")
-
-      it("should show dialog with error") {
-        verify(view).apply {
-          showProgressDialog()
-          dismissProgressDialog()
-          showErrorDialog(error.message!!)
-        }
-      }
-
-      it("should not close") {
-        verifyZeroInteractions(traveler)
-      }
-    }
+    Mockito.reset(view, bugRepositoryBuilder, bugRepository, extrasHandler, traveler)
   }
 
-})
+  @Test
+  fun test_onAttach_buildRepository_andSetScreenshotImage() {
+    whenever(bugRepositoryBuilder.build()).thenReturn(bugRepository)
+    whenever(extrasHandler.extraRepositoryBuilder).thenReturn(bugRepositoryBuilder)
+    whenever(extrasHandler.screenshotFilePath).thenReturn("any.jpg")
+
+    presenter.attach(view, traveler, extrasHandler)
+
+    verify(bugRepositoryBuilder).build()
+    verify(view).setScreenshotImage("any.jpg")
+  }
+
+  @Test
+  fun test_onSendButtonClick_createBug() {
+    whenever(extrasHandler.screenshotFilePath).thenReturn("any.jpg")
+    whenever(extrasHandler.logsFilePath).thenReturn("log.log")
+    whenever(bugRepository.create("title", "description", "any.jpg", "log.log"))
+        .thenReturn(answer())
+
+    presenter.onSendButtonClick("title", "description")
+
+    verify(view).showProgressDialog()
+    verify(view).dismissProgressDialog()
+    verify(view).showSuccessToast()
+    verify(traveler).close()
+  }
+
+  @Test
+  fun test_onSendButtonClick_withEmptyTitle_showError() {
+    presenter.onSendButtonClick("", "description")
+
+    verify(view).showErrorDialog(any())
+    verifyNoMoreInteractions(view)
+  }
+
+  @Test
+  fun test_onSendButtonClick_withEmptyDescription_showError() {
+    presenter.onSendButtonClick("title", "")
+
+    verify(view).showErrorDialog(any())
+    verifyNoMoreInteractions(view)
+  }
+
+  @Test
+  fun test_onSendButtonClick_withErrorOnRequest_showError() {
+    val error = Throwable("Something happened")
+
+    whenever(extrasHandler.screenshotFilePath).thenReturn("any.jpg")
+    whenever(extrasHandler.logsFilePath).thenReturn("log.log")
+    whenever(bugRepository.create("title", "description", "any.jpg", "log.log"))
+        .thenReturn(Observable.error(error))
+
+    presenter.onSendButtonClick("title", "description")
+
+
+    verify(view).showProgressDialog()
+    verify(view).dismissProgressDialog()
+    verify(view).showErrorDialog(error.message!!)
+    verifyZeroInteractions(traveler)
+  }
+
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -18,7 +18,10 @@ android {
     debug {
       minifyEnabled true
       shrinkResources true
+
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'rules.pro'
+
+      versionNameSuffix "-staging"
 
       buildConfigField "String", "PIVOTAL_API_KEY", "\"$ARTIST_PIVOTAL_API_KEY\""
       buildConfigField "String", "PIVOTAL_PROJECT_ID", "\"$ARTIST_PIVOTAL_PROJECT_ID\""

--- a/sample/rules.pro
+++ b/sample/rules.pro
@@ -43,6 +43,6 @@
 -keep class android.support.v7.widget.RecyclerView$ItemAnimator
 -keep class android.support.v4.app.DialogFragment
 -keep class android.support.v4.app.Fragment
--keep class android.support.v4.app.FragmentActivity
+-keep class android.support.v4.app.Activity
 -keep class android.support.design.widget.FloatingActionButton
 -keep class android.support.v7.widget.AppCompatImageHelper

--- a/sample/src/debug/java/debug_artist/sample/BaseActivity.java
+++ b/sample/src/debug/java/debug_artist/sample/BaseActivity.java
@@ -1,6 +1,5 @@
 package debug_artist.sample;
 
-import android.os.Build;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.Toast;
@@ -12,12 +11,9 @@ import debug_artist.menu.drawer.item.phoenix.RestartListener;
 import debug_artist.menu.drawer.item.spinner.SpinnerDrawerItem;
 import debug_artist.menu.drawer.item.spinner.SpinnerItemListener;
 import debug_artist.menu.report_bug.BugRepository;
+import debug_artist.menu.utils.device.AndroidDevice;
 import debug_artist.reporter_pivotaltracker.PivotalBugRepositoryBuilder;
-import java.util.LinkedHashMap;
 import java.util.Map;
-
-import static android.os.Build.MANUFACTURER;
-import static android.os.Build.MODEL;
 
 public class BaseActivity extends AppCompatActivity
     implements SpinnerItemListener, RestartListener, InputItemListener {
@@ -28,15 +24,19 @@ public class BaseActivity extends AppCompatActivity
   protected void onResume() {
     super.onResume();
 
+    // Define a list of strings that withSpinnerItem will need
     String[] hosts = new String[] { "Value 1", "Value 2" };
 
+    // Define your bug repository builder to happy report bugs to your third party services
+    Map<String, String> properties = AndroidDevice.getProjectProperties(this);
     BugRepository.Builder repositoryBuilder =
         new PivotalBugRepositoryBuilder(BuildConfig.PIVOTAL_API_KEY,
-            BuildConfig.PIVOTAL_PROJECT_ID, getProperties(),
-            new String[] { "android-sample" });
+            BuildConfig.PIVOTAL_PROJECT_ID, properties, new String[] { "android-sample" });
+
+    BaseApplication applicationInstance = BaseApplication.sInstance;
 
     // Create debug drawer with selected features
-    mDebugDrawer = new DebugDrawer(BaseApplication.sInstance, this)
+    mDebugDrawer = new DebugDrawer(applicationInstance, this)
         .withScalpelSwitch((ScalpelFrameLayout) findViewById(R.id.scalpelLayout))
         .withLeakCanarySwitch(true)
         .withPicassoLogsSwitch(true)
@@ -49,9 +49,9 @@ public class BaseActivity extends AppCompatActivity
         .withInputItem(2, "Host", this)
         .withSpinnerItem(1, "Spinner with item selected by index", hosts, 0, this)
         .withDivider()
-        .withInfoProperties(getProperties());
+        .withInfoProperties();
 
-    // Enable view debuger on some devices
+    // Enable view debugger on some devices
     ViewServer.get(this).addWindow(this);
   }
 
@@ -63,20 +63,7 @@ public class BaseActivity extends AppCompatActivity
     ViewServer.get(this).removeWindow(this);
   }
 
-  /**
-   * Return a map with keys and values referencing environment variables
-   */
-  public Map<String, String> getProperties() {
-    return new LinkedHashMap<String, String>() {{
-      put("BuildType", BuildConfig.BUILD_TYPE);
-      put("AppVersion", BuildConfig.VERSION_NAME);
-      put("BuildNumber", String.valueOf(BuildConfig.VERSION_CODE));
-      put("AndroidVersion", Build.VERSION.RELEASE);
-      put("Manufacturer", MANUFACTURER);
-      put("Model", MODEL);
-    }};
-  }
-
+  //<editor-fold desc="DebugDrawer events for SpinnerItemListener, RestartListener, InputItemListener">
   @Override
   public void onSpinnerItemClick(SpinnerDrawerItem item, int itemId, CharSequence title) {
     Toast.makeText(this, "Selected: " + title, Toast.LENGTH_LONG).show();
@@ -91,4 +78,5 @@ public class BaseActivity extends AppCompatActivity
   public void onTextInputEnter(int itemId, String inputText) {
     Toast.makeText(this, inputText, Toast.LENGTH_LONG).show();
   }
+  //</editor-fold>
 }


### PR DESCRIPTION
Now you can add device properties without manual creation

```
.withProperties()
```
instead of:

```
.withProperties(propertiesDictionary)
```

or get those properties with `AndroidDevice.getProjectProperties()`