### PR TITLE
Release 0.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# v 0.6.7
+- Fix last release dependencies for `reporter-pivotal` contains project reference "lib" causing clients crash on compile.
+
 # v 0.6.6
 - Fix missing library dependencies on generated pom.
 

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -154,11 +154,13 @@ task install(type: Upload, dependsOn: assemble) {
       def dependenciesNode = asNode().appendNode('dependencies')
 
       configurations.compile.allDependencies.each {
-        def dependencyNode = dependenciesNode.appendNode('dependency')
+        if (it.name != "lib") {
+          def dependencyNode = dependenciesNode.appendNode('dependency')
 
-        dependencyNode.appendNode('groupId', it.group)
-        dependencyNode.appendNode('artifactId', it.name)
-        dependencyNode.appendNode('version', it.version)
+          dependencyNode.appendNode('groupId', it.group)
+          dependencyNode.appendNode('artifactId', it.name)
+          dependencyNode.appendNode('version', it.version)
+        }
       }
     }
   }

--- a/lib/gradle.properties
+++ b/lib/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.6.6
-VERSION_CODE=32
+VERSION_NAME=0.6.7
+VERSION_CODE=33
 GROUP=com.baristav.debugartist
 
 POM_NAME=Debug Artist

--- a/reporter-pivotal/gradle.properties
+++ b/reporter-pivotal/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=0.6.6
-VERSION_CODE=7
+VERSION_NAME=0.6.7
+VERSION_CODE=8
 GROUP=com.baristav.debugartist
 
 POM_NAME=Debug Artist - Pivotal Tracker reporter

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -74,6 +74,9 @@ dependencies {
   compile(project(':lib')) { transitive = true }
   compile(project(':reporter-pivotal')) { transitive = true }
 
+  //compile('com.baristav.debugartist:debugartist:0.6.6@aar') { transitive = true }
+  //compile('com.baristav.debugartist:reporter_pivotal:0.6.6@aar') { transitive = true }
+
   // For StethoActivity
   compile 'com.facebook.stetho:stetho-okhttp3:1.5.0'
   compile "com.squareup.retrofit2:retrofit:${sampleVersions.retrofit}"


### PR DESCRIPTION
Fix last release dependencies for `reporter-pivotal` contains project reference "lib" causing clients crash on compile.
