### PR TITLE
Remove RxLint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# v 0.6.10
+- Remove `RxLint` from features since it may break in a lot of possible ways on the clients.
+
 # v 0.6.9
 - Update Kotlin 1.2.21
 - Update RxJava

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -51,7 +51,6 @@ dependencies {
   compile 'com.squareup.picasso:picasso:2.5.2'
   compile 'com.github.pedrovgs:lynx:1.6'
   compile 'com.jakewharton:process-phoenix:2.0.0'
-  compile 'nl.littlerobots.rxlint:rxlint:1.6'
   compile 'com.facebook.stetho:stetho:1.5.0'
 
   // Bug Reporter

--- a/lib/gradle.properties
+++ b/lib/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.6.9
+VERSION_NAME=0.6.10
 VERSION_CODE=35
 GROUP=com.baristav.debugartist
 

--- a/reporter-pivotal/gradle.properties
+++ b/reporter-pivotal/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.6.9
+VERSION_NAME=0.6.10
 VERSION_CODE=10
 GROUP=com.baristav.debugartist
 


### PR DESCRIPTION
Related to:
https://bitbucket.org/littlerobots/rxlint/issues/26/some-version-break-with-projects-that-uses

Newer RxLint requires you to use the new android gradle plugin (3.x) to work, creating a crash on compilation otherwise.